### PR TITLE
bug fixes

### DIFF
--- a/R/borehole_low_fidelity.R
+++ b/R/borehole_low_fidelity.R
@@ -21,7 +21,7 @@ quackquack_borehole_low_fidelity <- function(){
   out$response_type <- "uni"
 
   RR <- cbind(c(0.05, 100, 63070, 990, 63.1,  700, 1120, 9855),
-              c(0.15, 50000, 115600, 1110, 116, 80, 1680, 12045))
+              c(0.15, 50000, 115600, 1110, 116, 820, 1680, 12045))
   rownames(RR) <- c("rw", "r", "Tu", "Hu", "Tl", "Hl", "L", "Kw")
   out$input_range <- RR
   return(out)

--- a/R/dts_sirs.R
+++ b/R/dts_sirs.R
@@ -32,7 +32,16 @@
 #' set.seed(111)
 #' sir <- dts_sirs(x, Tf = 365)
 #' ts.plot(sir[,2], main="Number of infectious individuals", xlab="Time (days)", ylab="")
-dts_sirs <- function(x, scale01=TRUE, Tf=90, N0= 1000){
+dts_sirs <- function(x, scale01=TRUE, Tf=90, N0=1000){
+  if(x[1] + x[2] > 1) {
+    warning(paste("Initial proportions S0 + I0 =", round(x[1] + x[2], 3),
+                  "> 1. Normalizing to S0 =", round(x[1] / (x[1] + x[2]), 3),
+                  "and I0 =", round(x[2] / (x[1] + x[2]), 3)))
+    total_prop <- x[1] + x[2]
+    x[1] <- x[1] / total_prop
+    x[2] <- x[2] / total_prop
+  }
+
   S <- I <- R <- N <- rep(0, Tf)
   N[1] <- N0
   S[1] <- round(x[1]*N0)

--- a/R/dts_sirs.R
+++ b/R/dts_sirs.R
@@ -33,19 +33,14 @@
 #' sir <- dts_sirs(x, Tf = 365)
 #' ts.plot(sir[,2], main="Number of infectious individuals", xlab="Time (days)", ylab="")
 dts_sirs <- function(x, scale01=TRUE, Tf=90, N0=1000){
-  if(x[1] + x[2] > 1) {
-    warning(paste("Initial proportions S0 + I0 =", round(x[1] + x[2], 3),
-                  "> 1. Normalizing to S0 =", round(x[1] / (x[1] + x[2]), 3),
-                  "and I0 =", round(x[2] / (x[1] + x[2]), 3)))
-    total_prop <- x[1] + x[2]
-    x[1] <- x[1] / total_prop
-    x[2] <- x[2] / total_prop
+  if(x[1] + x[2] >= 1) {
+    warning(paste("I0 will be reduced from", x[2], "to", 1 - x[1], "due to S0 constraint"))
   }
 
   S <- I <- R <- N <- rep(0, Tf)
   N[1] <- N0
   S[1] <- round(x[1]*N0)
-  I[1] <- round(x[2]*N0)
+  I[1] <- round(min(1-x[1],x[2])*N0)
   R[1] <- N[1] - S[1] - I[1]
 
   for(t in 2:Tf){

--- a/R/dts_sirs.R
+++ b/R/dts_sirs.R
@@ -34,13 +34,13 @@
 #' ts.plot(sir[,2], main="Number of infectious individuals", xlab="Time (days)", ylab="")
 dts_sirs <- function(x, scale01=TRUE, Tf=90, N0=1000){
   if(x[1] + x[2] > 1) {
-    warning(paste("I0 will be reduced from", x[2], "to", 1 - x[1], "due to S0 constraint"))
+    warning(paste("S0 will be reduced from", x[1], "to", 1 - x[2], "due to I0 constraint"))
   }
 
   S <- I <- R <- N <- rep(0, Tf)
   N[1] <- N0
   S[1] <- round(x[1]*N0)
-  I[1] <- round(min(1-x[1],x[2])*N0)
+  I[1] <- round(min(1-x[2],x[1])*N0)
   R[1] <- N[1] - S[1] - I[1]
 
   for(t in 2:Tf){

--- a/R/dts_sirs.R
+++ b/R/dts_sirs.R
@@ -39,8 +39,8 @@ dts_sirs <- function(x, scale01=TRUE, Tf=90, N0=1000){
 
   S <- I <- R <- N <- rep(0, Tf)
   N[1] <- N0
-  S[1] <- round(x[1]*N0)
-  I[1] <- round(min(1-x[2],x[1])*N0)
+  S[1] <- round(min(1-x[2],x[1])*N0)
+  I[1] <- round(x[2]*N0)
   R[1] <- N[1] - S[1] - I[1]
 
   for(t in 2:Tf){

--- a/R/dts_sirs.R
+++ b/R/dts_sirs.R
@@ -33,7 +33,7 @@
 #' sir <- dts_sirs(x, Tf = 365)
 #' ts.plot(sir[,2], main="Number of infectious individuals", xlab="Time (days)", ylab="")
 dts_sirs <- function(x, scale01=TRUE, Tf=90, N0=1000){
-  if(x[1] + x[2] >= 1) {
+  if(x[1] + x[2] > 1) {
     warning(paste("I0 will be reduced from", x[2], "to", 1 - x[1], "due to S0 constraint"))
   }
 

--- a/R/dts_sirs.R
+++ b/R/dts_sirs.R
@@ -9,8 +9,8 @@
 #' @details
 #' Parameter description
 #' \describe{
-#'   \item{x1 = S0}{Proportion of population initally susceptible, [0, 1]}
-#'   \item{x2 = I0}{Proportion of population initially infected, [0, 1]}
+#'   \item{x1 = I0}{Proportion of population initally infected, [0, 1]}
+#'   \item{x2 = S0_without_I0}{Proportion of non-infected population initially susceptible, [0, 1]}
 #'   \item{x3 = beta}{transimissability parameter, [0, 1]. The upper bound is not meaningful, and the number of new infections is given by `rbinom(1, S[t-1], 1 - exp(-beta*I[t-1]/N[t-1]))`.}
 #'   \item{x4 = gamma}{recovery parameter, [0, 1]. The probability that each infectious person (independently) recovers at each time step. 1/gamma is the average length of infectious period}
 #'   \item{x5 = alpha}{birth rate.  [0, 1]. Parameter range is not entirely meaningful. Births always enter into susceptible class as `rpois(1, alpha*N[t-1])`}
@@ -25,7 +25,7 @@
 #' add a reference
 #' @export
 #' @examples
-#' x <- c(S0 = 0.99, I0 = 0.01,
+#' x <- c(I0 = 0.01, S0_without_I0 = 1.00,
 #'    beta = 0.12, gamma = 0.1,
 #'    alpha = 0, muS = 0, muI = 0,
 #'    muR = 0, delta = 1/90)
@@ -33,14 +33,10 @@
 #' sir <- dts_sirs(x, Tf = 365)
 #' ts.plot(sir[,2], main="Number of infectious individuals", xlab="Time (days)", ylab="")
 dts_sirs <- function(x, scale01=TRUE, Tf=90, N0=1000){
-  if(x[1] + x[2] > 1) {
-    warning(paste("S0 will be reduced from", x[1], "to", 1 - x[2], "due to I0 constraint"))
-  }
-
   S <- I <- R <- N <- rep(0, Tf)
   N[1] <- N0
-  S[1] <- round(min(1-x[2],x[1])*N0)
-  I[1] <- round(x[2]*N0)
+  I[1] <- round(x[1]*N0)
+  S[1] <- floor(x[2]*(N0 - I[1]))
   R[1] <- N[1] - S[1] - I[1]
 
   for(t in 2:Tf){
@@ -72,7 +68,7 @@ quackquack_dts_sirs <- function(){
 
   RR <- cbind(rep(0, 9),
               rep(1, 9))
-  rownames(RR) <- c("S0", "I0", "beta", "gamma", "alpha", "muS", "muI", "muR", "delta")
+  rownames(RR) <- c("I0", "S0_without_I0", "beta", "gamma", "alpha", "muS", "muI", "muR", "delta")
   out$input_range <- RR
   return(out)
 }


### PR DESCRIPTION
`borehole_low_fidelity.R` : upper bound of $H_l$ should be 820, not 80.
`dts_sirs.R`: clip $S_0$ (initial proportion of population susceptible) to be $\le 1 - I_0$ (where $I_0$ is the initial proportion of population infected) and display a warning message if values are changed. This prevents negative values from being passed as the 'number of trials' arg when sampling distributions.